### PR TITLE
Add BrowserStack SDK sample (Java · Gauge · Selenium · Automate)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ logs/
 gauge_bin
 target/
 browserstack.err
+*.log
+local.log
+reports/

--- a/README-SDK.md
+++ b/README-SDK.md
@@ -1,0 +1,56 @@
+# Gauge (Java) with BrowserStack SDK
+
+Run Gauge + Selenium specs on BrowserStack using the [BrowserStack Java SDK](https://www.browserstack.com/docs/automate/selenium/sdk-installation).
+The SDK attaches as a `-javaagent`, reads `browserstack.yml`, and instruments WebDriver — capabilities and
+the hub URL come from `browserstack.yml`, not from the test code or `env/*.properties`.
+
+> This is the SDK sample (on the `sdk` branch). The legacy capability-based sample (`env/*.properties`,
+> the manual `RemoteWebDriver` setup in `src/test/java/.../SearchSpec.java`) is preserved for reference.
+
+## Prerequisites
+
+- A [BrowserStack](https://www.browserstack.com/) account (username + access key)
+- JDK 8+ and Maven
+- Gauge CLI (`gauge`) — see https://docs.gauge.org/getting_started/installing-gauge
+
+## Setup
+
+```bash
+git clone -b sdk https://github.com/browserstack/gauge-java-browserstack.git
+cd gauge-java-browserstack
+mvn -q dependency:resolve
+```
+
+Configure credentials — set `userName`/`accessKey` in `browserstack.yml`, or:
+
+```bash
+export BROWSERSTACK_USERNAME="YOUR_USERNAME"
+export BROWSERSTACK_ACCESS_KEY="YOUR_ACCESS_KEY"
+```
+
+## Run Sample Test
+
+The add-to-cart spec (`sample-specs/add-to-cart.spec`) across the platforms in `browserstack.yml`:
+
+```bash
+# Resolve the SDK jar and attach it as the agent to Gauge's runner JVM:
+export GAUGE_JAVA_OPTS="-javaagent:$(mvn -q help:evaluate -Dexpression=settings.localRepository -DforceStdout)/com/browserstack/browserstack-java-sdk/*/browserstack-java-sdk-*.jar"
+mvn gauge:execute -DspecsDir=sample-specs
+```
+
+## Run Local Test
+
+Verifies the BrowserStack Local tunnel (`browserstackLocal: true` starts it automatically):
+
+```bash
+mvn gauge:execute -DspecsDir=sample-local-specs
+```
+
+## Notes
+
+- Results: [BrowserStack Automate dashboard](https://automate.browserstack.com/).
+- Product features (Accessibility, Percy, Observability) are `browserstack.yml` keys — `testObservability: true` is on by default.
+
+> ⚠️ **Verify before publishing:** Gauge forks a JVM for the Java runner, so the SDK `-javaagent` must reach
+> that JVM (here via `GAUGE_JAVA_OPTS`). Confirm the exact attach mechanism / `framework: gauge` token with
+> the Java SDK owner — this combo's wiring is best-effort and was not run live (no credentials available).

--- a/browserstack.yml
+++ b/browserstack.yml
@@ -1,0 +1,27 @@
+userName: YOUR_USERNAME
+accessKey: YOUR_ACCESS_KEY
+projectName: BrowserStack Samples
+buildName: browserstack build
+buildIdentifier: '#${BUILD_NUMBER}'
+# Gauge runs on the BrowserStack Java SDK (javaagent). framework token = gauge.
+framework: gauge
+platforms:
+  - os: OS X
+    osVersion: Big Sur
+    browserName: Chrome
+    browserVersion: latest
+  - os: Windows
+    osVersion: 10
+    browserName: Edge
+    browserVersion: latest
+  - deviceName: Samsung Galaxy S22 Ultra
+    browserName: chrome
+    osVersion: 12.0
+parallelsPerPlatform: 1
+browserstackAutomation: true
+browserstackLocal: true
+source: gauge-java-browserstack:sample-sdk:v1.0
+testObservability: true
+debug: false
+networkLogs: false
+consoleLogs: errors

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
             <artifactId>gauge-java</artifactId>
             <version>0.9.1</version>
         </dependency>
+        <!-- BrowserStack SDK: instruments WebDriver via the -javaagent (see README-SDK.md). -->
+        <dependency>
+            <groupId>com.browserstack</groupId>
+            <artifactId>browserstack-java-sdk</artifactId>
+            <version>LATEST</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
SDK-integrated Gauge (Java) sample with -javaagent wired via Maven.
**Live status: NOT yet validated** — local gauge run blocked by the legacy repo's non-default spec-dir layout (gauge resolves `specs/`). For review.

Generated via the SDK sample-repo generator. Tracking: SDK-6221.